### PR TITLE
prefer fs.exists over deprecated path.exists

### DIFF
--- a/lib/plugins/fs-node.js
+++ b/lib/plugins/fs-node.js
@@ -9,6 +9,7 @@ var fs = require("fs")
 var spawn = require('child_process').spawn
 var util = require("util")
 var Path = require("path")
+var Exists = fs.exists || Path.exists
 
 var POSTORDER = 0
 var PREORDER = 1
@@ -74,7 +75,7 @@ async.plugin({
 
     exists: function() {
         return this.$unaryOp(function(path, next) {
-            Path.exists(path, function(exists) {
+            Exists(path, function(exists) {
                 next(null, exists)
             })
         }, "exists")
@@ -198,7 +199,7 @@ async.plugin({
             if (gen)
                 return gen.next(callback)
 
-            Path.exists(head, function(exists){
+            Exists(head, function(exists){
                 if (!exists)
                     return callback(async.STOP)
 
@@ -285,7 +286,7 @@ async.plugin({
             if (gen)
                 return gen.next(callback)
 
-            Path.exists(path, function(exists) {
+            Exists(path, function(exists) {
                 if (!exists)
                     return callback(async.STOP)
 
@@ -334,7 +335,7 @@ async.plugin({
                 destPath = Path.join(destPath, Path.basename(srcPath))
 
             if (!force) {
-                Path.exists(destPath, function(exists) {
+                Exists(destPath, function(exists) {
                     if (exists)
                         callback("destination file already exists!")
                     else
@@ -369,7 +370,7 @@ async.plugin({
         if (destPath.indexOf(srcPath) == 0 && destPath.charAt(srcPath.length) == "/")
             return callback("the destination path is inside of the source path")
 
-        Path.exists(destPath, function(exists) {
+        Exists(destPath, function(exists) {
             if (!exists)
                 fs.mkdir(destPath, 0755, walk)
             else


### PR DESCRIPTION
This prevents a nuisance warning being written to the console
