### PR TITLE
Make builds run faster

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,5 @@ node_js:
   - 0.12
   - 4.0
   - 4.1
+
+sudo: false


### PR DESCRIPTION
Allow running builds faster on travis ci by setting sudo: false.

http://docs.travis-ci.com/user/workers/container-based-infrastructure/